### PR TITLE
Use png instead of webp

### DIFF
--- a/DiscordFreeEmojis.plugin.js
+++ b/DiscordFreeEmojis.plugin.js
@@ -143,7 +143,13 @@ function Start() {
     }
 
     function replaceEmoji(parseResult, emoji) {
-        parseResult.content = parseResult.content.replace(`<${emoji.animated ? "a" : ""}:${emoji.originalName || emoji.name}:${emoji.id}>`, emoji.url.split("?")[0] + "?size=48");
+        let sliceIndex = -5;
+        let currentEmojiFormat = ".png"
+        if (emoji.url.split("?")[0].slice(sliceIndex, sliceIndex + 1) != ".") {
+            sliceIndex = -4;
+            currentEmojiFormat = ".gif"
+        }
+        parseResult.content = parseResult.content.replace(`<${emoji.animated ? "a" : ""}:${emoji.originalName || emoji.name}:${emoji.id}>`, emoji.url.split("?")[0].slice(0, sliceIndex) + currentEmojiFormat + "?size=48&quality=lossless");
     }
 
     parseHook = function() {

--- a/DiscordFreeEmojis.user.js
+++ b/DiscordFreeEmojis.user.js
@@ -114,7 +114,13 @@ function Init(final)
     }
 
     function replaceEmoji(parseResult, emoji) {
-        parseResult.content = parseResult.content.replace(`<${emoji.animated ? "a" : ""}:${emoji.originalName || emoji.name}:${emoji.id}>`, emoji.url.split("?")[0] + "?size=48");
+        let sliceIndex = -5;
+        let currentEmojiFormat = ".png"
+        if (emoji.url.split("?")[0].slice(sliceIndex, sliceIndex + 1) != ".") {
+            sliceIndex = -4;
+            currentEmojiFormat = ".gif"
+        }
+        parseResult.content = parseResult.content.replace(`<${emoji.animated ? "a" : ""}:${emoji.originalName || emoji.name}:${emoji.id}>`, emoji.url.split("?")[0].slice(0, sliceIndex) + currentEmojiFormat + "?size=48&quality=lossless");
     }
 	
     const original_parse = messageEmojiParserModule.parse;

--- a/DiscordFreeEmojis64px.plugin.js
+++ b/DiscordFreeEmojis64px.plugin.js
@@ -143,7 +143,13 @@ function Start() {
     }
 
     function replaceEmoji(parseResult, emoji) {
-        parseResult.content = parseResult.content.replace(`<${emoji.animated ? "a" : ""}:${emoji.originalName || emoji.name}:${emoji.id}>`, emoji.url.split("?")[0] + "?size=64");
+        let sliceIndex = -5;
+        let currentEmojiFormat = ".png"
+        if (emoji.url.split("?")[0].slice(sliceIndex, sliceIndex + 1) != ".") {
+            sliceIndex = -4;
+            currentEmojiFormat = ".gif"
+        }
+        parseResult.content = parseResult.content.replace(`<${emoji.animated ? "a" : ""}:${emoji.originalName || emoji.name}:${emoji.id}>`, emoji.url.split("?")[0].slice(0, sliceIndex) + currentEmojiFormat + "?size=64&quality=lossless");
     }
 
     parseHook = function() {

--- a/DiscordFreeEmojis64px.user.js
+++ b/DiscordFreeEmojis64px.user.js
@@ -114,7 +114,13 @@ function Init(final)
     }
 
     function replaceEmoji(parseResult, emoji) {
-        parseResult.content = parseResult.content.replace(`<${emoji.animated ? "a" : ""}:${emoji.originalName || emoji.name}:${emoji.id}>`, emoji.url.split("?")[0] + "?size=64");
+        let sliceIndex = -5;
+        let currentEmojiFormat = ".png"
+        if (emoji.url.split("?")[0].slice(sliceIndex, sliceIndex + 1) != ".") {
+            sliceIndex = -4;
+            currentEmojiFormat = ".gif"
+        }
+        parseResult.content = parseResult.content.replace(`<${emoji.animated ? "a" : ""}:${emoji.originalName || emoji.name}:${emoji.id}>`, emoji.url.split("?")[0].slice(0, sliceIndex) + currentEmojiFormat + "?size=64&quality=lossless");
     }
 	
     const original_parse = messageEmojiParserModule.parse;

--- a/DiscordFreeEmojisSplit48px.plugin.js
+++ b/DiscordFreeEmojisSplit48px.plugin.js
@@ -159,7 +159,13 @@ function Start() {
     }
 
     function replaceEmoji(parseResult, emoji) {
-        parseResult.content = parseResult.content.replace(`<${emoji.animated ? "a" : ""}:${emoji.originalName || emoji.name}:${emoji.id}>`, emoji.url.split("?")[0] + "?size=48");
+        let sliceIndex = -5;
+        let currentEmojiFormat = ".png"
+        if (emoji.url.split("?")[0].slice(sliceIndex, sliceIndex + 1) != ".") {
+            sliceIndex = -4;
+            currentEmojiFormat = ".gif"
+        }
+        parseResult.content = parseResult.content.replace(`<${emoji.animated ? "a" : ""}:${emoji.originalName || emoji.name}:${emoji.id}>`, emoji.url.split("?")[0].slice(0, sliceIndex) + currentEmojiFormat + "?size=48&quality=lossless");
     }
 
     parseHook = function() {


### PR DESCRIPTION
As shown [here](https://github.com/QbDesu/BetterDiscordAddons/issues/59), using png instead of webp has a noticeable improvement on emote quality.